### PR TITLE
Run and package Stroke Looper as an Electron app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *~
 node_modules
+dist
 .tern-port
+*.log

--- a/main.js
+++ b/main.js
@@ -1,0 +1,53 @@
+const electron = require('electron');
+// Module to control application life.
+const {app} = electron;
+// Module to create native browser window.
+const {BrowserWindow} = electron;
+
+// Keep a global reference of the window object, if you don't, the window will
+// be closed automatically when the JavaScript object is garbage collected.
+let win;
+
+function createWindow() {
+  // Create the browser window.
+  win = new BrowserWindow({width: 1050, height: 667});
+
+  // and load the index.html of the app.
+  win.loadURL(`file://${__dirname}/index.html`);
+
+  // Open the DevTools.
+  // win.webContents.openDevTools();
+
+  // Emitted when the window is closed.
+  win.on('closed', () => {
+    // Dereference the window object, usually you would store windows
+    // in an array if your app supports multi windows, this is the time
+    // when you should delete the corresponding element.
+    win = null;
+  });
+}
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.on('ready', createWindow);
+
+// Quit when all windows are closed.
+app.on('window-all-closed', () => {
+  // On OS X it is common for applications and their menu bar
+  // to stay active until the user quits explicitly with Cmd + Q
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+app.on('activate', () => {
+  // On OS X it's common to re-create a window in the app when the
+  // dock icon is clicked and there are no other windows open.
+  if (win === null) {
+    createWindow();
+  }
+});
+
+// In this file you can include the rest of your app's specific main process
+// code. You can also put them in separate files and require them here.

--- a/package.json
+++ b/package.json
@@ -1,15 +1,18 @@
 {
     "name": "stroke-looper",
-    "version": "0.0.1",
+    "productName": "Stroke Looper",
+    "version": "0.1.0",
     "main": "main.js",
     "directories": {
       "test": "tests"
     },
     "scripts": {
         "test": "test",
-        "electron": "electron ."
+        "electron": "electron .",
+        "packager": "electron-packager . --all --out=dist/ --ignore=dist/*"
     },
-    "devDependencies" : {
+    "devDependencies": {
+        "electron-packager": "^7.0.2",
         "electron-prebuilt": "^1.1.0",
         "webdriverio": "^3.4.0",
         "selenium-standalone": "5.1.0"

--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
     "name": "stroke-looper",
     "version": "0.0.1",
+    "main": "main.js",
     "directories": {
       "test": "tests"
     },
     "scripts": {
-        "test": "test"
+        "test": "test",
+        "electron": "electron ."
     },
     "devDependencies" : {
+        "electron-prebuilt": "^1.1.0",
         "webdriverio": "^3.4.0",
         "selenium-standalone": "5.1.0"
     },


### PR DESCRIPTION
Allows to run the Stroke Looper as an Electron app (which embeds Chromium and Node.js), as well as to package it for all platforms. Usage:

Install prebuilt binaries of Electron and Electron Packager:

```bash
stroke-looper$ npm install
```

To run the app, assuming the Electron prebuilt binaries were installed:

```bash
stroke-looper$ npm run electron
```

To package the app, assuming the Electron Packager was installed:

```bash
stroke-looper$ npm run packager
```

This will provide executables for all platforms and architectures supported by the Electron Packager: Windows, Linux and Mac OS X (IA32 and x64).